### PR TITLE
Create Milwaukee custard guide website

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,176 @@
+:root {
+  --primary-color: #1c3d6e;
+  --accent-color: #f2a65a;
+  --background: #fffaf2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Open Sans', Arial, sans-serif;
+  line-height: 1.6;
+  background-color: var(--background);
+  color: #2c2a27;
+}
+
+header {
+  background-color: #113a63;
+  color: white;
+  padding: 1.5rem 1rem;
+}
+
+header h1 {
+  margin: 0;
+  border: 2px solid blue;
+  padding: 0.5rem 1rem;
+  display: inline-block;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+nav {
+  margin-top: 1rem;
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+nav a {
+  color: #fffcf4;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+nav a:hover,
+nav a:focus {
+  text-decoration: underline;
+}
+
+main {
+  padding: 2rem 1.5rem 3rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.hero {
+  background-image: url('../images/cream-pattern.svg');
+  background-size: cover;
+  background-position: center;
+  padding: 2rem;
+  border-radius: 16px;
+  margin-bottom: 2rem;
+  text-align: center;
+  box-shadow: 0 8px 20px rgba(28, 61, 110, 0.15);
+}
+
+.hero h2 {
+  margin-top: 0;
+  color: var(--primary-color);
+}
+
+.hero p {
+  max-width: 680px;
+  margin: 1rem auto 0;
+  font-size: 1.1rem;
+}
+
+p {
+  margin-bottom: 1.25rem;
+}
+
+img.responsive {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+}
+
+.lead-letter {
+  font-weight: 700;
+  font-size: 1.5em;
+  color: var(--accent-color);
+  margin-right: 0.1em;
+}
+
+section.instance-content {
+  background-color: rgba(255, 255, 255, 0.85);
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 10px 24px rgba(17, 58, 99, 0.12);
+}
+
+.instance-content ul,
+.instance-content ol {
+  padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.instance-content dl {
+  margin-bottom: 1.5rem;
+}
+
+.instance-content dt {
+  font-weight: 700;
+  color: var(--primary-color);
+}
+
+.instance-content dd {
+  margin: 0 0 0.75rem 1.25rem;
+}
+
+.instance-content a {
+  color: var(--primary-color);
+  font-weight: 600;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1rem;
+  background-color: #113a63;
+  color: #fefefe;
+}
+
+footer a {
+  color: #f3d8a3;
+}
+
+body.purple-door {
+  font-family: 'Roboto', Arial, sans-serif;
+}
+
+body.purple-door h2,
+body.purple-door .flavor-highlights {
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+}
+
+body.leons {
+  font-family: 'Helvetica Neue', Helvetica, sans-serif;
+}
+
+body.leons h2,
+body.leons .history {
+  font-family: 'Merriweather', Georgia, serif;
+}
+
+body.kopps {
+  font-family: 'Gill Sans', 'Segoe UI', sans-serif;
+}
+
+body.kopps h2,
+body.kopps .experience {
+  font-family: 'Cormorant Garamond', 'Times New Roman', serif;
+}
+
+.return-home {
+  display: inline-block;
+  margin-top: 1rem;
+}

--- a/images/cream-pattern.svg
+++ b/images/cream-pattern.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#fff6e8" />
+  <g stroke="#f5d3a5" stroke-width="6" stroke-linecap="round">
+    <path d="M20 40h160" />
+    <path d="M20 100h160" />
+    <path d="M20 160h160" />
+  </g>
+  <g stroke="#fbe8c3" stroke-width="14" stroke-linecap="round">
+    <path d="M40 20v160" />
+    <path d="M100 20v160" />
+    <path d="M160 20v160" />
+  </g>
+</svg>

--- a/images/home-feature.svg
+++ b/images/home-feature.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250" viewBox="0 0 400 250">
+  <defs>
+    <linearGradient id="sunset" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8d0ff" />
+      <stop offset="100%" stop-color="#c7e4ff" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="250" fill="url(#sunset)" rx="32" />
+  <g fill="#1c3d6e" font-family="'Trebuchet MS', sans-serif" font-weight="bold">
+    <text x="40" y="110" font-size="48">Milwaukee Treats</text>
+    <text x="40" y="165" font-size="32">Custard Capital of the World</text>
+  </g>
+  <g fill="#fff3c9" stroke="#f2a65a" stroke-width="4">
+    <circle cx="340" cy="70" r="28" />
+    <circle cx="320" cy="170" r="24" />
+    <circle cx="360" cy="150" r="18" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Milwaukee Custard Trail</title>
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Milwaukee's Sweet Custard Trail</h1>
+      <nav aria-label="Main navigation">
+        <ul>
+          <li><a href="purple-door.html">Purple Door Ice Cream</a></li>
+          <li><a href="leons.html">Leon's Frozen Custard</a></li>
+          <li><a href="kopps.html">Kopp's Frozen Custard</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <h2>Plan a Delicious Custard Crawl</h2>
+        <p>
+          Sample Milwaukee's most beloved frozen treats with curated tips for
+          three legendary stops in the Cream City.
+        </p>
+      </section>
+      <img
+        class="responsive"
+        src="images/home-feature.svg"
+        alt="Colorful illustration celebrating Milwaukee frozen custard"
+      />
+      <p>
+        <span class="lead-letter">M</span>ilwaukee is famous for its creamy,
+        velvety custard stands that keep locals coming back decade after decade.
+        <span class="lead-letter">W</span>hen the weather warms up, the city
+        buzzes with talk of the seasonal flavor releases and late-night cones.
+        <span class="lead-letter">L</span>ocals and visitors alike can savor a
+        scoop (or two) while exploring the welcoming neighborhoods that define
+        the city's food scene.
+      </p>
+    </main>
+    <footer>
+      <p>
+        Designed for the Milwaukee Web Lab. Learn more about the city's treats
+        at <a href="https://www.visitmilwaukee.org/">Visit Milwaukee</a>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/kopps.html
+++ b/kopps.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kopp's Frozen Custard</title>
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body class="kopps">
+    <header>
+      <h1>Kopp's Frozen Custard</h1>
+      <nav aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="purple-door.html">Purple Door Ice Cream</a></li>
+          <li><a href="leons.html">Leon's Frozen Custard</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <section class="instance-content">
+        <h2>Modern Flavors, Iconic Burgers</h2>
+        <p class="experience">
+          Kopp's expansive custard stands draw crowds for both towering sundaes
+          and savory butter burgers. Daily rotating flavors are announced online
+          and can include everything from tiramisu to lemon blueberry shortbread.
+        </p>
+        <p>
+          Each suburban location features airy patios, lush landscaping, and
+          plenty of space to linger with friends. Grab a flavor-of-the-day pint
+          to take home while enjoying the famous "squeaky" Wisconsin cheese curds
+          on-site.
+        </p>
+        <h3>Flavor-of-the-Day Preview</h3>
+        <dl>
+          <dt>Featured Custard</dt>
+          <dd>New York Cherry Cheesecake</dd>
+          <dt>Sundae Special</dt>
+          <dd>Grasshopper Fudge with mint and hot fudge ribbons</dd>
+          <dt>Take-Home Pint</dt>
+          <dd>Chocolate Peanut Butter for easy freezer stocking</dd>
+        </dl>
+        <p>
+          See the complete custard calendar at
+          <a href="https://www.kopps.com/flavor-preview" target="_blank" rel="noopener noreferrer"
+            >kopps.com</a
+          >, and remember to bring an appetite for their crispy onion rings.
+        </p>
+        <a class="return-home" href="index.html">Return to the Custard Trail Home</a>
+      </section>
+    </main>
+    <footer>
+      <p>
+        Ready for more Milwaukee sweets? Head back to the
+        <a href="index.html">Milwaukee custard guide</a>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/leons.html
+++ b/leons.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Leon's Frozen Custard</title>
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body class="leons">
+    <header>
+      <h1>Leon's Frozen Custard</h1>
+      <nav aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="purple-door.html">Purple Door Ice Cream</a></li>
+          <li><a href="kopps.html">Kopp's Frozen Custard</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <section class="instance-content">
+        <h2>South Side Tradition Since 1942</h2>
+        <p class="history">
+          Leon's neon-lit stand has served as a neighborhood beacon for more
+          than eighty years, attracting classic car clubs, families, and
+          late-night snackers. The menu remains refreshingly simple with an
+          emphasis on custard made fresh throughout the day.
+        </p>
+        <p>
+          Visitors can expect generous portions, speedy service, and a sense of
+          nostalgia that feels straight out of the 1950s. The custard pairs
+          perfectly with a drive down Historic Highway 41 or a stroll through
+          nearby Jackson Park on warm summer nights.
+        </p>
+        <h3>How to Make the Most of Your Visit</h3>
+        <ol>
+          <li>Check the flavor board for the day's specials as soon as you park.</li>
+          <li>Order a turtle sundae and a side of crunchy butter pecans.</li>
+          <li>Enjoy your custard beneath the glowing marquee lights.</li>
+        </ol>
+        <p>
+          Explore Leon's history and menu at
+          <a href="https://www.leonsfrozencustard.us/" target="_blank" rel="noopener noreferrer"
+            >leonsfrozencustard.us</a
+          >, and bring cash for their famously efficient walk-up windows.
+        </p>
+        <a class="return-home" href="index.html">Return to the Custard Trail Home</a>
+      </section>
+    </main>
+    <footer>
+      <p>
+        Continue your journey with a stop at
+        <a href="kopps.html">Kopp's Frozen Custard</a>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/purple-door.html
+++ b/purple-door.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Purple Door Ice Cream</title>
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body class="purple-door">
+    <header>
+      <h1>Purple Door Ice Cream</h1>
+      <nav aria-label="Site navigation">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="leons.html">Leon's Frozen Custard</a></li>
+          <li><a href="kopps.html">Kopp's Frozen Custard</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <section class="instance-content">
+        <h2>Small-Batch Creativity in Walker's Point</h2>
+        <p>
+          Purple Door Ice Cream showcases Milwaukee's imaginative spirit with
+          hand-crafted flavors made from locally sourced ingredients. Owners
+          Lauren and Steve Schultz have been churning out inventive combinations
+          that spotlight Wisconsin dairy since 2011.
+        </p>
+        <p class="flavor-highlights">
+          Popular favorites like salted caramel and whiskey pecan rotate
+          alongside seasonal scoops inspired by community partners. Grab a pint
+          to go, or enjoy a scoop while exploring the galleries and murals that
+          give Walker's Point its colorful character.
+        </p>
+        <h3>Flavor Flight Suggestions</h3>
+        <ul>
+          <li>Brown Butter Bourbon Pecan</li>
+          <li>Raspberry Green Tea</li>
+          <li>Valentina Hot Chocolate</li>
+        </ul>
+        <p>
+          Plan your visit at the
+          <a href="https://purpledooricecream.com/" target="_blank" rel="noopener noreferrer"
+            >Purple Door website</a
+          >, and save room to try their rotating menu of signature sandwiches.
+        </p>
+        <a class="return-home" href="index.html">Return to the Custard Trail Home</a>
+      </section>
+    </main>
+    <footer>
+      <p>
+        Discover more flavors when you head back to the
+        <a href="index.html">Milwaukee custard guide</a>.
+      </p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a four-page Milwaukee custard trail site featuring Purple Door, Leon's, and Kopp's
- apply shared styling, typography, and locally stored imagery via a central CSS file
- remove the obsolete single-page website placeholder

## Testing
- Not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e53c4ace28832eb90f4ec314a6a1fa