### PR TITLE
Simplify hero background styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -62,22 +62,25 @@ main {
 }
 
 .hero {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  margin-bottom: 2rem;
+  color: #ffffff;
   background-image: url('../images/IceCreamBackground.jpg');
-  background-size: cover;
-  background-position: center;
   background-repeat: no-repeat;
-  min-height: 300px;
+  background-position: center top;
+  background-size: 520px;
+  min-height: 260px;
 }
 
 .hero h2 {
-  margin-top: 0;
-  color: var(--primary-color);
+  margin: 0 0 0.5rem;
 }
 
 .hero p {
-  max-width: 680px;
-  margin: 1rem auto 0;
-  font-size: 1.1rem;
+  margin: 0 auto;
+  max-width: 540px;
+  font-size: 1.05rem;
 }
 
 p {


### PR DESCRIPTION
## Summary
- remove the tinted overlay so the hero image shows without a box effect
- simplify the hero section CSS and keep the background image smaller and centered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e542901a28832e9767e899623c8143